### PR TITLE
Fix Bayes' theorem equation formatting in QMD file

### DIFF
--- a/_quarto.yaml
+++ b/_quarto.yaml
@@ -6,7 +6,7 @@ execute:
   cache: false
 
 book:
-  version: 2025.09.03
+  version: 2025.09.07
   google-analytics: G-30X6YBX6FJ
   title: Applied Network Science with R
   author: George G. Vega Yon, Ph.D.

--- a/es/_quarto.yaml
+++ b/es/_quarto.yaml
@@ -6,7 +6,7 @@ execute:
   cache: false
 
 book:
-  version: 2025.09.03
+  version: 2025.09.07
   google-analytics: G-30X6YBX6FJ
   title: Ciencia de Redes Aplicada con R
   author: George G. Vega Yon, Ph.D.

--- a/es/news.qmd
+++ b/es/news.qmd
@@ -1,9 +1,13 @@
 ---
 date: 2025-09-03
-date-modified: 2025-09-03
+date-modified: 2025-09-07
 ---
 
 # Novedades
+
+## Versión 2024.09.07
+
+- Se corrigieron errores tipográficos en las fórmulas del capítulo de estadística bayesiana y en el capítulo de comportamiento.
 
 ## Versión 2025.09.03
 

--- a/es/part-01-03-behavior.qmd
+++ b/es/part-01-03-behavior.qmd
@@ -1,3 +1,8 @@
+---
+date: 2024-09-07
+date-modified: 2025-09-07
+---
+
 # Comportamiento y coevolución
 
 :::{.content-hidden}
@@ -47,11 +52,11 @@ La estadística de exposición, $\left(\sum_{j\neq i}X_{ij}\right)^{-1}\left(\su
 El siguiente ejemplo de código muestra cómo estimar un efecto de exposición rezagada usando la función `glm` en R. El modelo que simularemos y estimaremos presenta un grafo de Bernoulli con 1,000 nodos y una densidad de 0.01.
 
 $$
-y_{it} = \theta_1 + \rho \text{Exposure}_{it} + \theta_2 w_i + \varepsilon
+y_{it} = \theta_1 + \rho \text{Exposure}_{i,t-1} + \theta_2 w_i + \varepsilon
 $$
   
 
-donde $\text{Exposure}_{it}$ es la estadística de exposición definida arriba, y $w_i$ es un vector de covariables. 
+donde $\text{Exposure}_{i,t-1}$ es la estadística de exposición definida arriba, y $w_i$ es un vector de covariables.
 
 ```{r}
 #| label: lagged-exposure

--- a/es/part-02-10-statistical-foundations.qmd
+++ b/es/part-02-10-statistical-foundations.qmd
@@ -14,13 +14,13 @@ La Regla de Bayes es una ecuación fundamental en estadística bayesiana. Con el
 Aquí, decimos que la probabilidad condicional de $X$ dado $Y$ puede expresarse en términos de la probabilidad condicional de $Y$ dado $X$. Por ejemplo, sea $X$ un vector desconocido de parámetros $\theta\in\Theta$ y $Y$ un conjunto de datos $D \sim f(\theta)$ cuyo proceso de generación de datos depende del $\theta$ no observado. Como la distribución posterior de los parámetros del modelo es en general, elusiva, en su lugar, usamos la regla de Bayes para reformular el problema:
 
 \begin{equation*}
-\Pr{\left(\theta|D\right)} = \frac{\Pr{\left(\theta|D\right)}\Pr{\left(\theta\right)}}{\Pr{\left(D\right)}}
+\Pr{\left(\theta|D\right)} = \frac{\Pr{\left(D|\theta\right)}\Pr{\left(\theta\right)}}{\Pr{\left(D\right)}}
 \end{equation*}
 
 Dado que el denominador de la ecuación no depende de $\theta$, podemos, en su lugar, escribir
 
 \begin{equation*}
-\Pr{\left(\theta|D\right)} \propto \Pr{\left(\theta|D\right)}\Pr{\left(\theta\right)}
+\Pr{\left(\theta|D\right)} \propto \Pr{\left(D|\theta\right)}\Pr{\left(\theta\right)}
 \end{equation*}
 
 En el mundo bayesiano, se asume que la distribución incondicional de los parámetros del modelo proviene de una distribución particular, mientras que en el mundo frecuentista, no se hacen suposiciones distribucionales sobre los parámetros del modelo. Lo último es entonces equivalente a decir que $\theta\sim \text{Uniforme}(-\infty, +\infty)$; por lo tanto, ¡incluso los frecuentistas asumen algo sobre los parámetros del modelo![^frequentists]

--- a/es/part-02-10-statistical-foundations.qmd
+++ b/es/part-02-10-statistical-foundations.qmd
@@ -1,3 +1,9 @@
+---
+date: 2024-09-07
+date-modified: 2025-09-07
+---
+
+
 # Regla de Bayes
 
 ::: {.callout-warning}

--- a/news.qmd
+++ b/news.qmd
@@ -1,9 +1,13 @@
 ---
 date: 2025-09-03
-date-modified: 2025-09-03
+date-modified: 2025-09-07
 ---
 
 # News
+
+## Version 2024.09.07
+
+- Corrected math typos in the Bayesian statistics chapter and the behavior chapter.
 
 ## Version 2025.09.03
 

--- a/part-01-03-behavior.qmd
+++ b/part-01-03-behavior.qmd
@@ -1,3 +1,8 @@
+---
+date: 2024-09-07
+date-modified: 2025-09-07
+---
+
 # Behavior and coevolution
 
 :::{.content-hidden}
@@ -42,11 +47,11 @@ The exposure statistic, $\left(\sum_{j\neq i}X_{ij}\right)^{-1}\left(\sum_{j\neq
 The following code example shows how to estimate a lagged exposure effect using the `glm` function in R. The model we will simulate and estimate features a Bernoulli graph with 1,000 nodes and a density of 0.01.
 
 $$
-y_{it} = \theta_1 + \rho \text{Exposure}_{it} + \theta_2 w_i + \varepsilon
+y_{it} = \theta_1 + \rho \text{Exposure}_{i,t-1} + \theta_2 w_i + \varepsilon
 $$
   
 
-where $\text{Exposure}_{it}$ is the exposure statistic defined above, and $w_i$ is a vector of covariates. 
+where $\text{Exposure}_{i,t-1}$ is the exposure statistic defined above, and $w_i$ is a vector of covariates.
 
 ```{r}
 #| label: lagged-exposure

--- a/part-02-10-statistical-foundations.qmd
+++ b/part-02-10-statistical-foundations.qmd
@@ -1,3 +1,8 @@
+---
+date: 2024-09-07
+date-modified: 2025-09-07
+---
+
 # Bayes' Rule
 
 Bayes' Rule is a fundamental equation in Bayesian statistics. With it, we can reformulate inferential problems by writing probabilities in terms of known quantities. Bayes' rule can be stated as follows:
@@ -9,13 +14,13 @@ Bayes' Rule is a fundamental equation in Bayesian statistics. With it, we can re
 Here, we say that the conditional probability of $X$ given $Y$ can be expressed in terms of the conditional probability of $Y$ given $X$. For example, let $X$ be an unknown vector of parameters $\theta\in\Theta$ and $Y$ a dataset $D \sim f(\theta)$ whose data generating process depends on the unobserved $\theta$. As the posterior distribution of model parameters is in general, elusive, instead, we use Bayes' rule to rephrase the problem:
 
 \begin{equation*}
-\Pr{\left(\theta|D\right)} = \frac{\Pr{\left(\theta|D\right)}\Pr{\left(\theta\right)}}{\Pr{\left(D\right)}}
+\Pr{\left(\theta|D\right)} = \frac{\Pr{\left(D|\theta\right)}\Pr{\left(\theta\right)}}{\Pr{\left(D\right)}}
 \end{equation*}
 
 Since the denominator of the equation does not depend on $\theta$, we can, instead, write
 
 \begin{equation*}
-\Pr{\left(\theta|D\right)} \propto \Pr{\left(\theta|D\right)}\Pr{\left(\theta\right)}
+\Pr{\left(\theta|D\right)} \propto \Pr{\left(D|\theta\right)}\Pr{\left(\theta\right)}
 \end{equation*}
 
 In the Bayesian world, the unconditional distribution of the model parameters is assumed to come from a particular distribution, whereas in the frequentist world, no distributional assumptions are made about the model parameters. The latter is then equivalent to saying that $\theta\sim \text{Uniform}(-\infty, +\infty)$; therefore, even frequentists assume something about the model parameters![^frequentists]


### PR DESCRIPTION
This pull request updates both the English and Spanish versions of the book to correct mathematical typos in the Bayesian statistics and behavior chapters, and synchronizes metadata (such as version numbers and modification dates) across multiple files. The changes ensure that formulas and terminology are accurate in both languages and that the book's versioning reflects the latest updates.

**Content corrections:**

* Corrected math formulas in the Bayesian statistics chapters in both English (`part-02-10-statistical-foundations.qmd`) and Spanish (`es/part-02-10-statistical-foundations.qmd`), specifically fixing the application of Bayes' rule. [[1]](diffhunk://#diff-3b61c65d8cf8e2560883320a41e8e6e0268b7590c9ff4a91260b3c4c21c43e03L12-R23) [[2]](diffhunk://#diff-d202b8e423383bde92a8956dff0234a8205cce5ac255af88d2fc03085d138df8L17-R29)
* Updated the model specification in the behavior chapters in both English (`part-01-03-behavior.qmd`) and Spanish (`es/part-01-03-behavior.qmd`) to clarify the use of lagged exposure statistics. [[1]](diffhunk://#diff-8623c6ca0371ca0842930c0bce162198d511ec6d60fb9116be9c17248b1a083dL45-R54) [[2]](diffhunk://#diff-7d6b234781f88027862f14e8e977afd9e320ff9d76160faa9d3a0bdf2f077997L50-R59)

**Metadata and documentation updates:**

* Added and updated front-matter metadata (dates, modification dates) in the affected chapters in both languages to reflect the new version and modification date. [[1]](diffhunk://#diff-8623c6ca0371ca0842930c0bce162198d511ec6d60fb9116be9c17248b1a083dR1-R5) [[2]](diffhunk://#diff-7d6b234781f88027862f14e8e977afd9e320ff9d76160faa9d3a0bdf2f077997R1-R5) [[3]](diffhunk://#diff-3b61c65d8cf8e2560883320a41e8e6e0268b7590c9ff4a91260b3c4c21c43e03R1-R5) [[4]](diffhunk://#diff-d202b8e423383bde92a8956dff0234a8205cce5ac255af88d2fc03085d138df8R1-R6)
* Updated book version numbers in both `_quarto.yaml` and `es/_quarto.yaml` to `2025.09.07`. [[1]](diffhunk://#diff-4af79b474728b22ae871d003aa7df4804c52a8f1338e16459541720f0a11a440L9-R9) [[2]](diffhunk://#diff-39980f339da9f46ae9101d4a96937959fe42a13bfe32e7bdebe418cc60e77791L9-R9)
* Added news entries in both English (`news.qmd`) and Spanish (`es/news.qmd`) summarizing the corrections made in this release. [[1]](diffhunk://#diff-500173f888ed099ecb79c1041d0b7d7d460c969da72416084fd507aa741e9b2eL3-R11) [[2]](diffhunk://#diff-8ca4430ec7e8ea4fb1740cfb7f6a635c9b3adbf768b9ceeddde62951dbedcea0L3-R11)